### PR TITLE
try to use bitbybit instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,51 +7,13 @@ name = "arbitrary-int"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993a810118f8f37e9c4411c86f1c4c940a09a7ab34b7bf2d88d06f50c553fab7"
-dependencies = [
- "defmt",
-]
 
 [[package]]
-name = "bilge"
-version = "0.3.0"
+name = "bitbybit"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279c74986684d5cc7bbbd079aa448e8f852992cd385d85bb3a37e374c087b065"
+checksum = "71d2a3353d70ac1091a33cbf31fc7e77b19091538a7e306e3740712af19807ca"
 dependencies = [
- "arbitrary-int",
- "bilge-impl",
-]
-
-[[package]]
-name = "bilge-defmt"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ead8c0d6102ab90d4c1da6d6babdbc875b0375744d09e067000e049681a121ee"
-dependencies = [
- "arbitrary-int",
- "bilge-defmt-impl",
- "defmt",
-]
-
-[[package]]
-name = "bilge-defmt-impl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e092d5465f6f45da23088763d314003e9b02490ed98d5decac7e55710ba7dd"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "bilge-impl"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1176e49f42fe135cd2b56465e4f7d07038d3728f5e9f27fb2f08ed3fef75339"
-dependencies = [
- "itertools",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -113,28 +75,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
 name = "ieee802_3_miim"
 version = "0.9.1"
 dependencies = [
- "bilge",
- "bilge-defmt",
+ "arbitrary-int",
+ "bitbybit",
  "defmt",
  "nix",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -160,27 +107,6 @@ name = "phys"
 version = "0.1.0-pre"
 dependencies = [
  "ieee802_3_miim",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]

--- a/ieee802_3_miim/Cargo.toml
+++ b/ieee802_3_miim/Cargo.toml
@@ -11,12 +11,12 @@ categories = ["embedded", "no-std", "hardware-support"]
 readme = "../README.md"
 
 [features]
-defmt = [ "dep:defmt", "dep:bilge-defmt" ]
+defmt = [ "dep:defmt" ]
 
 [dependencies]
-bilge = "0.3.0"
 defmt = { version = "1", optional = true }
-bilge-defmt = { version = "0.2.0", optional = true }
+bitbybit = "2.0.0"
+arbitrary-int = "2.1.1"
 
 [dev-dependencies]
 nix = "0.31.2"

--- a/ieee802_3_miim/examples/phytool.rs
+++ b/ieee802_3_miim/examples/phytool.rs
@@ -1,6 +1,6 @@
 use std::num::ParseIntError;
 
-use bilge::prelude::u5;
+use arbitrary_int::u5;
 use ieee802_3_miim::{
     mdio::PhyAddress,
     registers::{
@@ -14,6 +14,7 @@ use ieee802_3_miim::{
 use crate::ioctl_mdio::IoctlMdio;
 
 mod ioctl_mdio {
+    use arbitrary_int::u5;
     use ieee802_3_miim::RegisterAddress;
     use nix::{
         errno::Errno,
@@ -109,7 +110,7 @@ mod ioctl_mdio {
             self.op(SIOCSMIIREG, address.get() as _, value);
         }
 
-        fn mmd_read(&mut self, device_address: bilge::prelude::u5, reg_address: u16) -> u16 {
+        fn mmd_read(&mut self, device_address: u5, reg_address: u16) -> u16 {
             // linux supports detection of MMD support through special PHY address,
             // PHY_ADDRESS = 0x8000 | (phy_address << 5) | dev_addr
             self.phy_address <<= 5;
@@ -124,12 +125,7 @@ mod ioctl_mdio {
             result
         }
 
-        fn mmd_write(
-            &mut self,
-            device_address: bilge::prelude::u5,
-            reg_address: u16,
-            reg_value: u16,
-        ) {
+        fn mmd_write(&mut self, device_address: u5, reg_address: u16, reg_value: u16) {
             // linux supports detection of MMD support through special PHY address,
             // PHY_ADDRESS = 0x8000 | (phy_address << 5) | dev_addr
             self.phy_address <<= 5;
@@ -152,19 +148,15 @@ mod ioctl_mdio {
             IoctlMdio::write_raw(self, address, value)
         }
 
-        fn mmd_read(&mut self, device_address: bilge::prelude::u5, reg_address: u16) -> u16
+        fn mmd_read(&mut self, device_address: u5, reg_address: u16) -> u16
         where
             Self: Sized,
         {
             IoctlMdio::mmd_read(self, device_address, reg_address)
         }
 
-        fn mmd_write(
-            &mut self,
-            device_address: bilge::prelude::u5,
-            reg_address: u16,
-            reg_value: u16,
-        ) where
+        fn mmd_write(&mut self, device_address: u5, reg_address: u16, reg_value: u16)
+        where
             Self: Sized,
         {
             IoctlMdio::mmd_write(self, device_address, reg_address, reg_value);
@@ -180,19 +172,15 @@ mod ioctl_mdio {
             IoctlMdio::write_raw(self, address, value)
         }
 
-        fn mmd_read(&mut self, device_address: bilge::prelude::u5, reg_address: u16) -> u16
+        fn mmd_read(&mut self, device_address: u5, reg_address: u16) -> u16
         where
             Self: Sized,
         {
             IoctlMdio::mmd_read(self, device_address, reg_address)
         }
 
-        fn mmd_write(
-            &mut self,
-            device_address: bilge::prelude::u5,
-            reg_address: u16,
-            reg_value: u16,
-        ) where
+        fn mmd_write(&mut self, device_address: u5, reg_address: u16, reg_value: u16)
+        where
             Self: Sized,
         {
             IoctlMdio::mmd_write(self, device_address, reg_address, reg_value);

--- a/ieee802_3_miim/src/lib.rs
+++ b/ieee802_3_miim/src/lib.rs
@@ -293,7 +293,7 @@ pub trait Miim {
     /// this operation.
     #[doc(alias = "clause45_read")]
     #[doc(alias = "clause 45")]
-    fn mmd_read(&mut self, device_address: bilge::prelude::u5, reg_address: u16) -> u16
+    fn mmd_read(&mut self, device_address: arbitrary_int::u5, reg_address: u16) -> u16
     where
         Self: Sized,
     {
@@ -308,7 +308,7 @@ pub trait Miim {
     /// this operation.
     #[doc(alias = "clause45_write")]
     #[doc(alias = "clause 45")]
-    fn mmd_write(&mut self, device_address: bilge::prelude::u5, reg_address: u16, reg_value: u16)
+    fn mmd_write(&mut self, device_address: arbitrary_int::u5, reg_address: u16, reg_value: u16)
     where
         Self: Sized,
     {

--- a/ieee802_3_miim/src/mmd.rs
+++ b/ieee802_3_miim/src/mmd.rs
@@ -1,12 +1,12 @@
 //! MDIO Manageable Device (MMD, Clause 45) access for MIIM PHYs.
 
-use bilge::{bitsize, prelude::*, FromBits};
+use arbitrary_int::u5;
 
 use crate::{Miim, RegisterAddress};
 
 /// The access mode for an MMD transaction.
-#[bitsize(2)]
-#[derive(FromBits, Debug)]
+#[bitbybit::bitenum(u2, exhaustive = true)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AccessMode {
     /// Transfer an address to the MMDs address
@@ -25,14 +25,14 @@ pub enum AccessMode {
 }
 
 /// Register 13 & 14
-#[bitsize(16)]
-#[derive(Clone, Copy, DebugBits, FromBits)]
-#[cfg_attr(feature = "defmt", derive(bilge_defmt::FormatBits))]
+#[bitbybit::bitfield(u16, forbid_overlaps, defmt_bitfields(feature = "defmt"))]
+#[derive(Debug, PartialEq)]
 pub struct MmdAccessControl {
     /// The device address.
+    #[bits(0..=4, rw)]
     pub device_address: u5,
-    reserved: u9,
     /// The access mode of the register.
+    #[bits(14..=15, rw)]
     pub mode: AccessMode,
 }
 
@@ -48,24 +48,28 @@ impl Mmd {
     /// Perform an MMD read of addres `reg_address` from device `device_address`
     ///  using the [`Miim::write_raw`] and [`Miim::read_raw`] functionality of `phy`.
     pub fn read<P: Miim>(phy: &mut P, device_address: u5, reg_address: u16) -> u16 {
-        let mut mmd_address = MmdAccessControl::new(device_address, AccessMode::Address);
-        phy.write_raw(MmdAccessControl::CONTROL_REG, mmd_address.value);
+        let mut mmd_address = MmdAccessControl::ZERO
+            .with_device_address(device_address)
+            .with_mode(AccessMode::Address);
+        phy.write_raw(MmdAccessControl::CONTROL_REG, mmd_address.raw_value());
         phy.write_raw(MmdAccessControl::DATA_ADDRESS_REG, reg_address);
 
         mmd_address.set_mode(AccessMode::Data);
-        phy.write_raw(MmdAccessControl::CONTROL_REG, mmd_address.value);
+        phy.write_raw(MmdAccessControl::CONTROL_REG, mmd_address.raw_value());
         phy.read_raw(MmdAccessControl::DATA_ADDRESS_REG)
     }
 
     /// Perform an MMD write at addres `reg_address` on device `device_address`
     ///  using the [`Miim::write_raw`] and [`Miim::read_raw`] functionality of `phy`.
     pub fn write<P: Miim>(phy: &mut P, device_address: u5, reg_address: u16, reg_data: u16) {
-        let mut mmd_address = MmdAccessControl::new(device_address, AccessMode::Address);
-        phy.write_raw(MmdAccessControl::CONTROL_REG, mmd_address.value);
+        let mut mmd_address = MmdAccessControl::ZERO
+            .with_device_address(device_address)
+            .with_mode(AccessMode::Address);
+        phy.write_raw(MmdAccessControl::CONTROL_REG, mmd_address.raw_value());
         phy.write_raw(MmdAccessControl::DATA_ADDRESS_REG, reg_address);
 
         mmd_address.set_mode(AccessMode::Data);
-        phy.write_raw(MmdAccessControl::CONTROL_REG, mmd_address.value);
+        phy.write_raw(MmdAccessControl::CONTROL_REG, mmd_address.raw_value());
         phy.write_raw(MmdAccessControl::DATA_ADDRESS_REG, reg_data)
     }
 }

--- a/ieee802_3_miim/src/registers.rs
+++ b/ieee802_3_miim/src/registers.rs
@@ -1,9 +1,5 @@
 //! MIIM register definitions.
 //!
-//! Currently, these registers do not provide a `Default` implementation, as picking
-//! a sensible default is difficult or impossible. However, all registers _do_ implement
-//! [`From<u16>`], which means that they can easily be constructed using `From::from(0)`.
-//!
 //! The `ID1` and `ID2` registers are not supported directly in this module. To access them,
 //! see [`Miim::phy_ident`](crate::Miim::phy_ident).
 //!
@@ -25,6 +21,26 @@
 // 0xd: MMD
 // 0xe: MMD
 // 0xf: basic
+
+fn assert_default<T: Default>() {}
+
+macro_rules! from_into {
+    ($name:ident) => {
+        impl From<u16> for $name {
+            fn from(value: u16) -> Self {
+                $name::new_with_raw_value(value)
+            }
+        }
+
+        impl From<$name> for u16 {
+            fn from(value: $name) -> Self {
+                crate::registers::assert_default::<$name>();
+
+                value.raw_value()
+            }
+        }
+    };
+}
 
 // Reg 2 and 3 are PHY ident and are handled at a higher
 // level.

--- a/ieee802_3_miim/src/registers/auto_negotiation.rs
+++ b/ieee802_3_miim/src/registers/auto_negotiation.rs
@@ -4,7 +4,7 @@
 //! are found in [`LeaderFollowerStatus`](super::leader_follower::LeaderFollowerStatus)
 //! and [`LeaderFollowerControl`](super::leader_follower::LeaderFollowerControl).
 
-use bilge::{bitsize, prelude::*, FromBits};
+use arbitrary_int::u7;
 
 use crate::registers::{Register, RegisterAddress};
 
@@ -12,28 +12,33 @@ use crate::registers::{Register, RegisterAddress};
 /// the information that this PHY advertises to its autonegotiation
 /// link partner.
 ///
-/// Specified in section 28.2.4.1.3 and 37.2.5.1.3
-#[bitsize(16)]
-#[derive(FromBits, DebugBits, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(bilge_defmt::FormatBits))]
+// Specified in section 28.2.4.1.3 and 37.2.5.1.3
+#[bitbybit::bitfield(u16, forbid_overlaps, default = 0, defmt_bitfields(feature = "defmt"))]
+#[derive(Debug, PartialEq)]
 pub struct AutonegotiationAdvertisement {
     /// The advertised selector (should be [`Selector::Sel802_3`]).
-    pub selector: Selector,
+    #[bits(0..=4, rw)]
+    pub selector: Option<Selector>,
     /// The advertised technology ability.
+    #[bits(5..=11, rw)]
     pub technology_ability: TechnologyAbility,
     /// Whether this PHY is able to transmit extended
     /// next pages.
+    #[bit(12, rw)]
     pub extended_next_page: bool,
     /// A remote fault has been detected.
+    #[bit(13, rw)]
     pub remote_fault: bool,
-    reserved: u1,
     /// The advertised next page bit.
     ///
     /// If this is `true`, the local PHY advertised that
     /// it wanted to perform a next-page exchange with its
     /// link partner.
+    #[bit(15, rw)]
     pub next_page: bool,
 }
+
+from_into!(AutonegotiationAdvertisement);
 
 impl Register for AutonegotiationAdvertisement {
     const ADDRESS: RegisterAddress = RegisterAddress::new(4).unwrap();
@@ -42,25 +47,32 @@ impl Register for AutonegotiationAdvertisement {
 /// The auto negotiation link partner ability register, containing (part of)
 /// the information that is advertised to this PHY by its link partner.
 ///
-/// Defined in section 28.2.4.1.4 and 37.2.5.1.4.
-#[bitsize(16)]
-#[derive(FromBits, DebugBits, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(bilge_defmt::FormatBits))]
+// Defined in section 28.2.4.1.4 and 37.2.5.1.4.
+#[bitbybit::bitfield(u16, forbid_overlaps, default = 0, defmt_bitfields(feature = "defmt"))]
+#[derive(Debug, PartialEq)]
 pub struct AutonegotiationLinkPartnerAbility {
     /// The selector advertised by the link partner (should be [`Selector::Sel802_3`]).
-    pub selector: Selector,
+    #[bits(0..=4, rw)]
+    pub selector: Option<Selector>,
     /// The technology ability advertised by the link partner.
+    #[bits(5..=11, rw)]
     pub technology_ability: TechnologyAbility,
     /// Whether an extended next page was transmitted by the link partner.
+    #[bit(12, rw)]
     pub extended_next_page: bool,
     /// Whether the link partner detected a local fault.
+    #[bit(13, rw)]
     pub remote_fault: bool,
     /// Whether the link partner's code word was received
     /// succesfully.
+    #[bit(14, rw)]
     pub acknowledge: bool,
     /// Whether the link partner wanted to engage in a next page exchange.
+    #[bit(15, rw)]
     pub next_page: bool,
 }
+
+from_into!(AutonegotiationLinkPartnerAbility);
 
 impl Register for AutonegotiationLinkPartnerAbility {
     const ADDRESS: RegisterAddress = RegisterAddress::new(5).unwrap();
@@ -68,33 +80,40 @@ impl Register for AutonegotiationLinkPartnerAbility {
 
 /// The autonegotiation expansion register.
 ///
-/// Defined in section 28.2.4.1.5 and 37.2.5.1.4.
-#[bitsize(16)]
-#[derive(FromBits, DebugBits, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(bilge_defmt::FormatBits))]
+// Defined in section 28.2.4.1.5 and 37.2.5.1.4.
+#[bitbybit::bitfield(u16, forbid_overlaps, default = 0, defmt_bitfields(feature = "defmt"))]
+#[derive(Debug, PartialEq)]
 pub struct AutonegotiationExpansion {
     /// The link partner is able to perform autonegotiation.
+    #[bit(0, rw)]
     pub link_partner_autonegotiation_able: bool,
     /// Whether a new page was received from the link partner.
     ///
     /// This field is reset to 0 when the register is read.
+    #[bit(1, rw)]
     pub page_received: bool,
     /// Whether the local device is next-page able.
+    #[bit(2, rw)]
     pub next_page_able: bool,
     /// Whether the link partner is next-page able.
+    #[bit(3, rw)]
     pub link_partner_next_page_able: bool,
     /// Whether a fault has been detected using the Parallel
     /// Detection Function.
+    #[bit(4, rw)]
     pub parallel_detection_fault: bool,
     /// If `true`, an optionally received Next Page is stored in register 8.
     /// If `false`, an optionally received Next Page is stored in register 5.
+    #[bit(5, rw)]
     pub received_next_page_storage_location: bool,
     /// If `true`, `received_next_page_storage_location` indicates the location
     /// in which an optionally received next page is stored. If `false`, the
     /// location of the next page is implementation-defined.
+    #[bit(6, rw)]
     pub receive_next_page_location_able: bool,
-    reserved: u9,
 }
+
+from_into!(AutonegotiationExpansion);
 
 impl Register for AutonegotiationExpansion {
     const ADDRESS: RegisterAddress = RegisterAddress::new(6).unwrap();
@@ -102,9 +121,9 @@ impl Register for AutonegotiationExpansion {
 
 /// A selector indicating the exact standard that a PHY implements.
 ///
-/// Defined in Annex 28A.
-#[bitsize(5)]
-#[derive(FromBits, Debug, Clone, Copy, PartialEq)]
+// Defined in Annex 28A.
+#[bitbybit::bitenum(u5)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[expect(missing_docs)]
 pub enum Selector {
@@ -113,29 +132,34 @@ pub enum Selector {
     Sel802_5v2001 = 0b00011,
     Sel1394 = 0b00100,
     INCITS = 0b00101,
-    #[fallback]
-    Reserved,
 }
 
 /// The technological abilities of a PHY with the 802.3 selector.
 ///
-/// Defined in Annex 28B.2 and 28D.
-#[bitsize(7)]
-#[derive(FromBits, DebugBits, Clone, Copy, PartialEq, Default)]
-#[cfg_attr(feature = "defmt", derive(bilge_defmt::FormatBits))]
+// Defined in Annex 28B.2 and 28D.
+#[bitbybit::bitfield(u7, forbid_overlaps, defmt_bitfields(feature = "defmt"))]
+#[derive(Debug, PartialEq, Default)]
+
 pub struct TechnologyAbility {
     /// Supports 10BASE-T, Half-Duplex.
+    #[bit(0, rw)]
     pub _10base_t_hd: bool,
     /// Supports 10BASE-T, Full-Duplex.
+    #[bit(1, rw)]
     pub _10base_t_fd: bool,
     /// Supports 100BASE-TX, Half-Duplex.
+    #[bit(2, rw)]
     pub _100base_tx_hd: bool,
     /// Supports 100BASE-TX, Full-Duplex.
+    #[bit(3, rw)]
     pub _100base_tx_fd: bool,
     /// Supports 100BASE-T4.
+    #[bit(4, rw)]
     pub _100base_t4: bool,
     /// Symmetric pause for full duplex links is supported.
+    #[bit(5, rw)]
     pub symmetric_pause: bool,
     /// Asymmetric pause for full duplex links is supported.
+    #[bit(6, rw)]
     pub asymmetric_pause: bool,
 }

--- a/ieee802_3_miim/src/registers/basic.rs
+++ b/ieee802_3_miim/src/registers/basic.rs
@@ -1,7 +1,5 @@
 //! The basic register set.
 
-use bilge::{bitsize, prelude::*, FromBits};
-
 use crate::{
     registers::{Register, RegisterAddress},
     LinkSpeed,
@@ -12,55 +10,72 @@ use crate::{
 /// This register reports part of the PHY's capabilities, and contains status
 /// flags.
 ///
-/// Defined in 22.2.4.2.
-#[bitsize(16)]
-#[derive(Clone, Copy, DebugBits, FromBits)]
-#[cfg_attr(feature = "defmt", derive(bilge_defmt::FormatBits))]
+// Defined in 22.2.4.2.
+#[bitbybit::bitfield(u16, forbid_overlaps, default = 0, defmt_bitfields(feature = "defmt"))]
+#[derive(Debug, PartialEq)]
 pub struct BasicStatus {
     /// Whether this PHY supports the extended capability registers (2-14, 16-31) defined
     /// by the standard.
+    #[bit(0, rw)]
     pub extended_capabilities: bool,
     /// Whether this PHY has detected a jabber event.
     ///
     /// This bit is cleared on a read of the register.
+    #[bit(1, rw)]
     pub jabber_detect: bool,
     /// Whether the PHY has detected a valid link.
+    #[bit(2, rw)]
     pub link_status: bool,
     /// Whether this PHY is able to perform autonegotiation.
+    #[bit(3, rw)]
     pub autonegotiate_able: bool,
     /// A remote fault was detected.
+    #[bit(4, rw)]
     pub remote_fault: bool,
     /// Autonegotiation has completed.
     ///
     /// Once this bit is set, the auto negotiation registers for
     /// the PHY are valid.
+    #[bit(5, rw)]
     pub autonegotiation_complete: bool,
     /// Whether this PHY supports reading management frames without
     /// management preamble.
     ///
     /// See 22.2.4.6.2 for more information about what this bit
     /// can be used for.
+    #[bit(6, rw)]
     pub mf_preamble_suppression: bool,
     /// Whether this PHY supports transmitting regardless of whether
     /// it has established a valid link.
+    #[bit(7, rw)]
     pub unidirectional_ability: bool,
     /// The PHY supports the [`ExtendedStatus`] register.
+    #[bit(8, rw)]
     pub extended_status: bool,
     /// The PHY supports 100BASE-T2, Half-Duplex.
+    #[bit(9, rw)]
     pub _100base_t2_hd: bool,
     /// The PHY supports 100BASE-T2, Full-Duplex.
+    #[bit(10, rw)]
     pub _100base_t2_fd: bool,
     /// The PHY supports 10BASE-T, Half-Duplex.
+    #[bit(11, rw)]
     pub _10base_t_hd: bool,
     /// The PHY supports 10BASE-T, Full-Duplex.
+    #[bit(12, rw)]
     pub _10base_t_fd: bool,
     /// The PHY supports 100BASE-X, Half-Duplex.
+    #[bit(13, rw)]
     pub _100base_x_hd: bool,
     /// The PHY supports 100BASE-X, Full-Duplex.
+    #[bit(14, rw)]
     pub _100base_x_fd: bool,
     /// The PHY supports 100BASE-T4.
+    #[bit(15, rw)]
     pub _100base_t4: bool,
 }
+
+from_into!(BasicStatus);
 
 impl Register for BasicStatus {
     const ADDRESS: RegisterAddress = RegisterAddress::new(1).unwrap();
@@ -73,29 +88,33 @@ impl Register for BasicStatus {
 /// this register, and standard-conforming GMII PHYs _must_ support this
 /// register).
 ///
-/// Defined in 22.2.4.4.
-#[bitsize(16)]
-#[derive(FromBits, DebugBits, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(bilge_defmt::FormatBits))]
+// Defined in 22.2.4.4.
+#[bitbybit::bitfield(u16, forbid_overlaps, default = 0, defmt_bitfields(feature = "defmt"))]
+#[derive(Debug, PartialEq)]
 pub struct ExtendedStatus {
-    reserved: u12,
+    #[bit(12, rw)]
     /// The PHY spuports 1000BASE-T, Half-Duplex.
     pub _1000base_t_hd: bool,
     /// The PHY spuports 1000BASE-T, Full-Duplex.
+    #[bit(13, rw)]
     pub _1000base_t_fd: bool,
     /// The PHY spuports 1000BASE-X, Half-Duplex.
+    #[bit(14, rw)]
     pub _1000base_x_hd: bool,
     /// The PHY spuports 1000BASE-X, Full-Duplex.
+    #[bit(15, rw)]
     pub _1000base_x_fd: bool,
 }
+
+from_into!(ExtendedStatus);
 
 impl Register for ExtendedStatus {
     const ADDRESS: RegisterAddress = RegisterAddress::new(15).unwrap();
 }
 
 /// A duplex mode.
-#[bitsize(1)]
-#[derive(Clone, Copy, Debug, FromBits, PartialEq, Eq, PartialOrd, Ord)]
+#[bitbybit::bitenum(u1, exhaustive = true)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Duplex {
     /// Full duplex.
@@ -146,17 +165,28 @@ impl LinkConfig {
 
 /// The Control Register, containing basic control bits.
 ///
-/// Defined in 37.2.5.1.1.
-#[bitsize(16)]
-#[derive(FromBits, DebugBits, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(bilge_defmt::FormatBits))]
+// Defined in 37.2.5.1.1.
+#[bitbybit::bitfield(u16, forbid_overlaps, default = 0, defmt_bitfields(feature = "defmt"))]
+#[derive(Debug, PartialEq)]
 pub struct BasicControl {
-    reserved: u5,
+    /// Do not access this field directly: use [`BasicControl::set_link_config`]
+    /// and [`BasicControl::get_link_config`] instead.
+    #[bit(5, rw)]
     unidirectional_enable: bool,
+    /// Do not access this field directly: use [`BasicControl::set_link_config`]
+    /// and [`BasicControl::get_link_config`] instead.
+    #[bit(6, rw)]
     speed_sel_msb: bool,
     /// Enable the collision test signal.
+    #[bit(7, rw)]
     pub collision_test: bool,
+    /// Do not access this field directly: use [`BasicControl::set_link_config`]
+    /// and [`BasicControl::get_link_config`] instead.
+    #[bit(8, rw)]
     duplex_mode: Duplex,
+    /// Do not access this field directly: use [`BasicControl::set_link_config`]
+    /// and [`BasicControl::get_link_config`] instead.
+    #[bit(9, rw)]
     restart_autonegotiation: bool,
     /// Electrically isolate the PHY from its (Gigabit) Media Independent
     /// Interface.
@@ -164,17 +194,27 @@ pub struct BasicControl {
     /// In other words, disconnect the PHY from the pins it shares
     /// with the MAC component connected to it. Setting this bit
     /// _does_ retain access to the PHY over MIIM.
+    #[bit(10, rw)]
     pub isolate: bool,
     /// Enable Power-Down mode.
+    #[bit(11, rw)]
     pub power_down: bool,
+    /// Do not access this field directly: use [`BasicControl::set_link_config`]
+    /// and [`BasicControl::get_link_config`] instead.
+    #[bit(12, rw)]
     autonegotiation_enable: bool,
+    /// Do not access this field directly: use [`BasicControl::set_link_config`]
+    /// and [`BasicControl::get_link_config`] instead.
+    #[bit(13, rw)]
     speed_sel_lsb: bool,
     /// Enable loopback mode.
+    #[bit(14, rw)]
     pub loopback: bool,
     /// Perform a reset.
     ///
     /// If set, this bit will stay high until the reset
     /// has completed.
+    #[bit(15, rw)]
     pub reset: bool,
 }
 
@@ -233,6 +273,8 @@ impl BasicControl {
         }
     }
 }
+
+from_into!(BasicControl);
 
 impl Register for BasicControl {
     const ADDRESS: RegisterAddress = RegisterAddress::new(0).unwrap();

--- a/ieee802_3_miim/src/registers/leader_follower.rs
+++ b/ieee802_3_miim/src/registers/leader_follower.rs
@@ -1,12 +1,12 @@
 //! Leader-follower registers.
 
-use bilge::{bitsize, prelude::*, FromBits};
+use arbitrary_int::u3;
 
 use crate::registers::{Register, RegisterAddress};
 
 /// The resolved or preference of port type.
-#[bitsize(1)]
-#[derive(Clone, Copy, FromBits, Debug, PartialEq)]
+#[bitbybit::bitenum(u1, exhaustive = true)]
+#[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PortType {
     /// The port is a follower.
@@ -21,30 +21,36 @@ pub enum PortType {
 /// bits, as well as configuration to be used during LEADER-FOLLOWER
 /// negotiation.
 ///
-/// Defined in 40.5.1.1.
-#[bitsize(16)]
-#[derive(Clone, Copy, FromBits, DebugBits)]
-#[cfg_attr(feature = "defmt", derive(bilge_defmt::FormatBits))]
+// Defined in 40.5.1.1.
+#[bitbybit::bitfield(u16, forbid_overlaps, default = 0, defmt_bitfields(feature = "defmt"))]
+#[derive(Debug, PartialEq)]
 pub struct LeaderFollowerControl {
-    reserved: u8,
     /// Advertise 1000BASE-T Half Duplex during
     /// autonegotiation.
+    #[bit(8, rw)]
     pub _1000base_t_hd: bool,
     /// Advertise 1000BASE-T Full Duplex during
     /// autonegotiation.
+    #[bit(9, rw)]
     pub _1000base_t_fd: bool,
     /// If `!manual_config`, indicate the type of port that
     /// this device should prefer to be.
+    #[bit(10, rw)]
     pub port_type_preference: PortType,
     /// If `manual_config`, set the port type that this device
     /// should use during negotiation.
+    #[bit(11, rw)]
     pub config_value: PortType,
     /// Whether manual or LEADER-FOLLOWER negotiation should be
     /// used to determine the [`PortType`] of this device.
+    #[bit(12, rw)]
     pub manual_config: bool,
     /// The test mode bits.
+    #[bits(13..=15, rw)]
     pub test_mode: u3,
 }
+
+from_into!(LeaderFollowerControl);
 
 impl Register for LeaderFollowerControl {
     const ADDRESS: RegisterAddress = RegisterAddress::new(9).unwrap();
@@ -56,35 +62,42 @@ impl Register for LeaderFollowerControl {
 /// bits, as well as status resolved during LEADER-FOLLOWER
 /// negotiation.
 ///
-/// Defined in 40.5.1.1.
-#[bitsize(16)]
-#[derive(Clone, Copy, FromBits, DebugBits)]
-#[cfg_attr(feature = "defmt", derive(bilge_defmt::FormatBits))]
+// Defined in 40.5.1.1.
+#[bitbybit::bitfield(u16, forbid_overlaps, default = 0, defmt_bitfields(feature = "defmt"))]
+#[derive(Debug, PartialEq)]
 pub struct LeaderFollowerStatus {
     /// The cumulative count of errors detected when the
     /// receiver is receiving idles.
     ///
     /// This field is reset to zero when the register is read.
+    #[bits(0..=7, rw)]
     pub idle_error_count: u8,
-    reserved: u2,
     /// Link partner advertises 1000BASE-T Half Duplex.
+    #[bit(10, rw)]
     pub _1000base_t_hd: bool,
     /// Link partner advertises 1000BASE-T Full Duplex.
+    #[bit(11, rw)]
     pub _1000base_t_fd: bool,
     /// Whether the remote receiver is OK, i.e. whether reception
     /// is detected to be reliable for our link partner.
+    #[bit(12, rw)]
     pub remote_receiver_ok: bool,
     /// Whether the local receiver is OK, i.e. whether reception
     /// is detected to be reliable for this PHY.
+    #[bit(13, rw)]
     pub local_receiver_ok: bool,
     /// The configuration that the local PHY resolved to.
+    #[bit(14, rw)]
     pub leader_follower_resolution: PortType,
     /// The combination of the local [`LeaderFollowerControl::config_value`] and
     /// the remote [`LeaderFollowerControl::config_value`] is invalid.
     ///
     /// This field is cleared when the register is read.
+    #[bit(15, rw)]
     pub leader_follower_config_fault: bool,
 }
+
+from_into!(LeaderFollowerStatus);
 
 impl Register for LeaderFollowerStatus {
     const ADDRESS: RegisterAddress = RegisterAddress::new(10).unwrap();


### PR DESCRIPTION
`bilge` has a compatibility warning, which is not great.

`bitbybit` seems like a viable alternative. It works well, but produces un-buildable builders if no default is provided for non-full structs. So decent, but make sure to provide a `default` for `bitbybit::bitfield`s

Left to do:
- [x] Mark relevant fields as read-only instead of everything being `rw`