### PR TITLE
Refactor link speed determination to use `ControlFlow`

### DIFF
--- a/ieee802_3_miim/src/lib.rs
+++ b/ieee802_3_miim/src/lib.rs
@@ -75,7 +75,7 @@ pub struct LinkState {
     /// The speed of the link.
     pub speed: LinkSpeed,
     /// The duplex mode of the link.
-    pub duplex: DuplexMode,
+    pub duplex: Duplex,
 }
 
 /// All basic link speeds possibly supported by the PHY.
@@ -289,8 +289,8 @@ pub trait Miim {
             (BasicControlLinkConfig::Manual { duplex, speed }, _) => Ok(LinkState {
                 speed,
                 duplex: match duplex {
-                    Duplex::Half => DuplexMode::Half,
-                    Duplex::Full { .. } => DuplexMode::Full,
+                    DuplexConfig::Half => Duplex::Half,
+                    DuplexConfig::Full { .. } => Duplex::Full,
                 },
             }),
             (BasicControlLinkConfig::Autonegotiate { .. }, false) => {
@@ -343,12 +343,12 @@ pub trait Miim {
                     if local_1000_fd && lp_1000_fd {
                         return Ok(LinkState {
                             speed: LinkSpeed::Mbps1000,
-                            duplex: DuplexMode::Full,
+                            duplex: Duplex::Full,
                         });
                     } else if local_1000_hd && lp_1000_hd {
                         return Ok(LinkState {
                             speed: LinkSpeed::Mbps1000,
-                            duplex: DuplexMode::Half,
+                            duplex: Duplex::Half,
                         });
                     }
                 }
@@ -371,13 +371,13 @@ pub trait Miim {
                 // Priority resolution as defined in IEEE 802.3-2022, Section 28B.3
                 // 100BASE-T2 and 100BASE-T4 are ignored
                 let (speed, duplex) = if local_100_fd && lp_100_fd {
-                    (LinkSpeed::Mbps100, DuplexMode::Full)
+                    (LinkSpeed::Mbps100, Duplex::Full)
                 } else if local_100_hd && lp_100_hd {
-                    (LinkSpeed::Mbps100, DuplexMode::Half)
+                    (LinkSpeed::Mbps100, Duplex::Half)
                 } else if local_10_fd && lp_10_fd {
-                    (LinkSpeed::Mbps10, DuplexMode::Full)
+                    (LinkSpeed::Mbps10, Duplex::Full)
                 } else if local_10_hd && lp_10_hd {
-                    (LinkSpeed::Mbps10, DuplexMode::Half)
+                    (LinkSpeed::Mbps10, Duplex::Half)
                 } else {
                     return Err(LinkStateError::NoMatchingTechnologies);
                 };
@@ -526,7 +526,7 @@ mod test {
             state,
             LinkState {
                 speed: crate::LinkSpeed::Mbps10,
-                duplex: crate::registers::DuplexMode::Full
+                duplex: crate::registers::Duplex::Full
             }
         )
     }
@@ -541,7 +541,7 @@ mod test {
             state,
             LinkState {
                 speed: crate::LinkSpeed::Mbps100,
-                duplex: crate::registers::DuplexMode::Full
+                duplex: crate::registers::Duplex::Full
             }
         )
     }
@@ -556,7 +556,7 @@ mod test {
             state,
             LinkState {
                 speed: crate::LinkSpeed::Mbps1000,
-                duplex: crate::registers::DuplexMode::Full
+                duplex: crate::registers::Duplex::Full
             }
         )
     }

--- a/ieee802_3_miim/src/lib.rs
+++ b/ieee802_3_miim/src/lib.rs
@@ -14,11 +14,11 @@ pub mod registers;
 use registers::*;
 
 use crate::registers::{
-    auto_negotiation::{
-        AutonegotiationAdvertisement, AutonegotiationExpansion, AutonegotiationLinkPartnerAbility,
-    },
-    leader_follower::{LeaderFollowerControl, LeaderFollowerStatus},
+    auto_negotiation::AutonegotiationAdvertisement, leader_follower::LeaderFollowerControl,
 };
+
+mod link_state;
+pub use link_state::{GetLinkStateProcess, LinkStateError};
 
 /// A MIIM register address.
 ///
@@ -45,31 +45,8 @@ impl RegisterAddress {
     }
 }
 
-/// Errors that can occur when attempting to determine
-/// the state of a link.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum LinkStateError {
-    /// No link has been established yet.
-    NoLink,
-    /// The PHY is configured for autonegotiation, but it does
-    /// not support autonegotiation.
-    NotAutonegotiationAble,
-    /// Autonegotiation is enabled, but has not completed yet.
-    AutonegotiationNotCompleted,
-    /// Autonegotiation is enabled, but the PHY does not support extended
-    /// capabilities. This means that it lacks the registers required to
-    /// read out the autonegotiation status, so the status cannot be read out.
-    ExtendedCapabilities,
-    /// Autonegotiation is enabled, but he link partner does not support auto negotiation.
-    LinkPartnerNotAutonegotiationAble,
-    /// None of the technologies supported by this PHY
-    /// are supported by the autonegotitation link partner, and vice-versa.
-    NoMatchingTechnologies,
-}
-
 /// The state of a link.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct LinkState {
     /// The speed of the link.
@@ -78,16 +55,16 @@ pub struct LinkState {
     pub duplex: Duplex,
 }
 
-/// All basic link speeds possibly supported by the PHY.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// All links speed that may be supported by a normal (R)(G)MII PHY.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum LinkSpeed {
-    /// 1000 Mbps
-    Mbps1000,
-    /// 100 Mbps
-    Mbps100,
     /// 10 Mbps
     Mbps10,
+    /// 100 Mbps
+    Mbps100,
+    /// 1000 Mbps
+    Mbps1000,
 }
 
 /// The PHY IDENT of this PHY
@@ -256,135 +233,20 @@ pub trait Miim {
     }
 
     /// Get the current link state of this PHY.
-    ///
-    /// All relevant bits (ignoring 100BASE-T2 and 100BASE-T4) are in IEEE 802.3-2022:
-    /// * 22.2.4.1 Control Register (Register 0)
-    /// * 22.2.4.2 Status register (Register 1)
-    /// * 22.2.4.3.7 MASTER-SLAVE control register (Register 9)
-    ///   which links to 40.5.1.1 1000BASE-T use of registers during Auto-Negotiation
-    /// * 22.2.4.3.8 MASTER-SLAVE status register (Register 10)
-    ///   which links to 40.5.1.1 1000BASE-T use of registers during Auto-Negotiation
-    /// * 28.2.4.1.3 Auto-Negotiation advertisement register (Register 4)
-    /// * 28.2.4.1.4 Auto-Negotiation Link Partner ability register (Register 5)
-    /// * 28.2.4.1.5 Auto-Negotiation expansion register (Register 6) (RO)
     fn get_link_state(&mut self) -> Result<LinkState, LinkStateError> {
-        let basic_control: BasicControl = self.read();
-        let basic_status: BasicStatus = self.read();
+        use core::ops::ControlFlow;
 
-        if !basic_status.link_status() {
-            return Err(LinkStateError::NoLink);
-        }
+        let process = match GetLinkStateProcess::start(self.read(), self.read()) {
+            ControlFlow::Continue(c) => c,
+            ControlFlow::Break(res) => return res,
+        };
 
-        // Having extended status is equivalent to being 1000 Mbit capable
-        let has_extended_status = basic_status.extended_status();
-        let gigabit_able = has_extended_status;
+        let process = match process.next(self.read(), self.read(), self.read()) {
+            ControlFlow::Continue(c) => c,
+            ControlFlow::Break(res) => return res,
+        };
 
-        // We don't need to check if the PHY is autonegotiation able:
-        // BasicControl must return 0 for autonegotiation enabled on
-        // PHYs that don't support it.
-        let link_config = basic_control.get_link_config();
-        let autoneg_completed = basic_status.autonegotiation_complete();
-
-        match (link_config, autoneg_completed) {
-            (BasicControlLinkConfig::Manual { duplex, speed }, _) => Ok(LinkState {
-                speed,
-                duplex: match duplex {
-                    DuplexConfig::Half => Duplex::Half,
-                    DuplexConfig::Full { .. } => Duplex::Full,
-                },
-            }),
-            (BasicControlLinkConfig::Autonegotiate { .. }, false) => {
-                Err(LinkStateError::AutonegotiationNotCompleted)
-            }
-            (BasicControlLinkConfig::Autonegotiate { .. }, true) => {
-                if !basic_status.extended_capabilities() {
-                    return Err(LinkStateError::ExtendedCapabilities);
-                }
-
-                let autoneg_exp: AutonegotiationExpansion = self.read();
-                let advertisement: AutonegotiationAdvertisement = self.read();
-
-                if !autoneg_exp.link_partner_autonegotiation_able() {
-                    return Err(LinkStateError::LinkPartnerNotAutonegotiationAble);
-                }
-
-                // Priority resolution as defined in IEEE 802.3-2022, Section 28B.3
-                // 100BASE-T2 and 100BASE-T4 are ignored
-                //
-                // IEEE 802.3-2022, Section 40.5.1.2 mandates that 1000BASE-T PHYs
-                // must send next pages, so using it as indication for whether
-                // the link partner supports gigabit makes sense. Additionally,
-                // we know that our local PHY supports it when gigabit is supported,
-                // so we can just reuse that knowledge.
-                //
-                // According to Table 40-3, the LEADER-FOLLOWER status bits
-                // are only valid if 6.1 Page Received bit has been set.
-                //
-                // However, this bit latches low, which means we can only use it to
-                // read the correct status once. Instead, we will assume
-                // that the link partner being next page able is enough of an indication
-                // of gigabit-ability.
-                //
-                // LEADER-FOLLOWER advertisement bits in LF Control only make sense if we
-                // sent a next page.
-                if gigabit_able
-                    && autoneg_exp.next_page_able()
-                    && autoneg_exp.link_partner_next_page_able()
-                {
-                    let lf_control: LeaderFollowerControl = self.read();
-                    let lf_status: LeaderFollowerStatus = self.read();
-
-                    let local_1000_fd = lf_control._1000base_t_fd();
-                    let local_1000_hd = lf_control._1000base_t_hd();
-
-                    let lp_1000_fd = lf_status._1000base_t_fd();
-                    let lp_1000_hd = lf_status._1000base_t_hd();
-
-                    if local_1000_fd && lp_1000_fd {
-                        return Ok(LinkState {
-                            speed: LinkSpeed::Mbps1000,
-                            duplex: Duplex::Full,
-                        });
-                    } else if local_1000_hd && lp_1000_hd {
-                        return Ok(LinkState {
-                            speed: LinkSpeed::Mbps1000,
-                            duplex: Duplex::Half,
-                        });
-                    }
-                }
-
-                let local_ta = advertisement.technology_ability();
-
-                let local_100_fd = local_ta._100base_tx_fd();
-                let local_100_hd = local_ta._100base_tx_hd();
-                let local_10_fd = local_ta._10base_t_fd();
-                let local_10_hd = local_ta._10base_t_fd();
-
-                let link_partner_ability: AutonegotiationLinkPartnerAbility = self.read();
-                let lp_ta = link_partner_ability.technology_ability();
-
-                let lp_100_fd = lp_ta._100base_tx_fd();
-                let lp_100_hd = lp_ta._100base_tx_hd();
-                let lp_10_fd = lp_ta._10base_t_fd();
-                let lp_10_hd = lp_ta._10base_t_hd();
-
-                // Priority resolution as defined in IEEE 802.3-2022, Section 28B.3
-                // 100BASE-T2 and 100BASE-T4 are ignored
-                let (speed, duplex) = if local_100_fd && lp_100_fd {
-                    (LinkSpeed::Mbps100, Duplex::Full)
-                } else if local_100_hd && lp_100_hd {
-                    (LinkSpeed::Mbps100, Duplex::Half)
-                } else if local_10_fd && lp_10_fd {
-                    (LinkSpeed::Mbps10, Duplex::Full)
-                } else if local_10_hd && lp_10_hd {
-                    (LinkSpeed::Mbps10, Duplex::Half)
-                } else {
-                    return Err(LinkStateError::NoMatchingTechnologies);
-                };
-
-                Ok(LinkState { speed, duplex })
-            }
-        }
+        process.next(self.read(), self.read())
     }
 
     /// Set the autonegotiation advertisement and restart the autonegotiation
@@ -437,126 +299,44 @@ pub trait Miim {
 }
 
 #[cfg(test)]
-mod test {
-    use crate::{LinkState, Miim, RegisterAddress};
-
-    struct MockPhy {
-        registers: [u16; 16],
-    }
-
-    impl Miim for MockPhy {
-        fn read_raw(&mut self, address: RegisterAddress) -> u16 {
-            self.registers[address.get() as usize]
-        }
-
-        fn write_raw(&mut self, address: RegisterAddress, value: u16) {
-            self.registers[address.get() as usize] = value;
-        }
-    }
-
-    const GIGABIT_GIGABIT_PARTNER: MockPhy = MockPhy {
-        #[rustfmt::skip]
-        registers: [
-            0x1000, 0x79ad, 0x001c, 0xc800, 0x0de1, 0xc1e1, 0x006d, 0x2001,
-            0x6001, 0x0200, 0x3800, 0x0000, 0x0000, 0x0000, 0x0000, 0x2000,
-        ],
-    };
-
-    const GIGABIT_100M_PARTNER: MockPhy = MockPhy {
-        #[rustfmt::skip]
-        registers: [
-            0x1040, 0x79ad, 0x001c, 0xc800, 0x0de1, 0x51e1, 0x0065, 0x2001,
-            0x0000, 0x0200, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x2000,
-        ],
-    };
-
-    const GIGABIT_10M_PARTNER: MockPhy = MockPhy {
-        #[rustfmt::skip]
-        registers: [
-        0x1000, 0x79ad, 0x001c, 0xc800, 0x01e1, 0x4061, 0x0067, 0x2801,
-        0x0000, 0x0200, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x2000,
-        ],
-    };
-
-    const LINK_NOT_UP: MockPhy = MockPhy {
-        #[rustfmt::skip]
-        registers: [
-            0x1000, 0x7989, 0x001c, 0xc800, 0x0de1, 0x0000, 0x0064, 2801,
-            0x0000, 0x0200, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 2000,
-        ],
-    };
-
-    const AUTONEG_INCOMPLETE: MockPhy = MockPhy {
-        #[rustfmt::skip]
-        registers: [
-            // Same as LINK_NOT_UP, but with link status bit set
-            0x1000, 0x7989 | (1 << 2), 0x001c, 0xc800, 0x0de1, 0x0000, 0x0064, 2801,
-            0x0000, 0x0200, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 2000,
-        ],
-    };
+mod link_ordering {
+    use crate::{registers::Duplex, LinkSpeed, LinkState};
 
     #[test]
-    fn link_not_up() {
-        let mut phy = LINK_NOT_UP;
-
-        let state = phy.get_link_state();
-
-        assert_eq!(state, Err(crate::LinkStateError::NoLink))
+    fn gig_greatest() {
+        assert!(LinkSpeed::Mbps1000 > LinkSpeed::Mbps100);
+        assert!(LinkSpeed::Mbps1000 > LinkSpeed::Mbps10);
     }
 
     #[test]
-    fn autoneg_incomplete() {
-        let mut phy = AUTONEG_INCOMPLETE;
-
-        let state = phy.get_link_state();
-
-        assert_eq!(
-            state,
-            Err(crate::LinkStateError::AutonegotiationNotCompleted)
-        )
+    fn _100_bigger_than_10() {
+        assert!(LinkSpeed::Mbps100 > LinkSpeed::Mbps10);
     }
 
     #[test]
-    fn link_state_10fd() {
-        let mut phy = GIGABIT_10M_PARTNER;
+    fn duplex_ordering() {
+        assert!(Duplex::Full > Duplex::Half);
+    }
 
-        let state = phy.get_link_state().unwrap();
-
-        assert_eq!(
-            state,
+    #[test]
+    fn link_state_ordering() {
+        assert!(
             LinkState {
-                speed: crate::LinkSpeed::Mbps10,
-                duplex: crate::registers::Duplex::Full
+                speed: LinkSpeed::Mbps1000,
+                duplex: Duplex::Full
+            } > LinkState {
+                speed: LinkSpeed::Mbps1000,
+                duplex: Duplex::Half
             }
-        )
-    }
+        );
 
-    #[test]
-    fn link_state_100fd() {
-        let mut phy = GIGABIT_100M_PARTNER;
-
-        let state = phy.get_link_state().unwrap();
-
-        assert_eq!(
-            state,
+        assert!(
             LinkState {
-                speed: crate::LinkSpeed::Mbps100,
-                duplex: crate::registers::Duplex::Full
-            }
-        )
-    }
-
-    #[test]
-    fn link_state_1gfd() {
-        let mut phy = GIGABIT_GIGABIT_PARTNER;
-
-        let state = phy.get_link_state().unwrap();
-
-        assert_eq!(
-            state,
-            LinkState {
-                speed: crate::LinkSpeed::Mbps1000,
-                duplex: crate::registers::Duplex::Full
+                speed: LinkSpeed::Mbps1000,
+                duplex: Duplex::Full
+            } > LinkState {
+                speed: LinkSpeed::Mbps100,
+                duplex: Duplex::Full
             }
         )
     }

--- a/ieee802_3_miim/src/lib.rs
+++ b/ieee802_3_miim/src/lib.rs
@@ -316,26 +316,29 @@ pub trait Miim {
                 // the link partner supports gigabit makes sense. Additionally,
                 // we know that our local PHY supports it when gigabit is supported,
                 // so we can just reuse that knowledge.
-                if gigabit_able && autoneg_exp.link_partner_next_page_able() {
+                //
+                // According to Table 40-3, the LEADER-FOLLOWER status bits
+                // are only valid if 6.1 Page Received bit has been set.
+                //
+                // However, this bit latches low, which means we can only use it to
+                // read the correct status once. Instead, we will assume
+                // that the link partner being next page able is enough of an indication
+                // of gigabit-ability.
+                //
+                // LEADER-FOLLOWER advertisement bits in LF Control only make sense if we
+                // sent a next page.
+                if gigabit_able
+                    && autoneg_exp.next_page_able()
+                    && autoneg_exp.link_partner_next_page_able()
+                {
                     let lf_control: LeaderFollowerControl = self.read();
                     let lf_status: LeaderFollowerStatus = self.read();
 
-                    // LEADER-FOLLOWER advertisement bits only make sense if we
-                    // sent a next page.
-                    let local_next_page = autoneg_exp.next_page_able();
-                    let local_1000_fd = local_next_page && lf_control._1000base_t_fd();
-                    let local_1000_hd = local_next_page && lf_control._1000base_t_hd();
+                    let local_1000_fd = lf_control._1000base_t_fd();
+                    let local_1000_hd = lf_control._1000base_t_hd();
 
-                    // According to 802.3-2022, Table 40-3, the LEADER-FOLLOWER status bits
-                    // are only valid if 6.1 Page Received bit has been set.
-                    //
-                    // However, this bit latches low, which means we can only use it to
-                    // read the correct status once. Instead, we will assume
-                    // that the link partner being next page able is enough of an indication
-                    // of gigabit-ability.
-                    let lp_next_page = autoneg_exp.link_partner_next_page_able();
-                    let lp_1000_fd = lp_next_page && lf_status._1000base_t_fd();
-                    let lp_1000_hd = lp_next_page && lf_status._1000base_t_hd();
+                    let lp_1000_fd = lf_status._1000base_t_fd();
+                    let lp_1000_hd = lf_status._1000base_t_hd();
 
                     if local_1000_fd && lp_1000_fd {
                         return Ok(LinkState {

--- a/ieee802_3_miim/src/lib.rs
+++ b/ieee802_3_miim/src/lib.rs
@@ -67,7 +67,7 @@ pub enum LinkSpeed {
     Mbps1000,
 }
 
-/// The PHY IDENT of this PHY
+/// The PHY IDENT of a [`Miim`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PhyIdent(u16, u16);

--- a/ieee802_3_miim/src/link_state.rs
+++ b/ieee802_3_miim/src/link_state.rs
@@ -1,0 +1,499 @@
+//! State machine for determining a [`Miim`]'s link state.
+//!
+//! Determine a PHY's [`LinkState`] based on the contents of the base set
+//! of MIIM registers. This code requires _no_ PHY-specific code beyond
+//! what is provided by [`Miim::read_raw`], and is the logic backing
+//! [`Miim::get_link_state`].
+///
+// All relevant bits (ignoring 100BASE-T2 and 100BASE-T4) are in IEEE 802.3-2022:
+// * 22.2.4.1 Control Register (Register 0)
+// * 22.2.4.2 Status register (Register 1)
+// * 22.2.4.3.7 MASTER-SLAVE control register (Register 9)
+//   which links to 40.5.1.1 1000BASE-T use of registers during Auto-Negotiation
+// * 22.2.4.3.8 MASTER-SLAVE status register (Register 10)
+//   which links to 40.5.1.1 1000BASE-T use of registers during Auto-Negotiation
+// * 28.2.4.1.3 Auto-Negotiation advertisement register (Register 4)
+// * 28.2.4.1.4 Auto-Negotiation Link Partner ability register (Register 5)
+// * 28.2.4.1.5 Auto-Negotiation expansion register (Register 6) (RO)
+
+#[cfg(doc)]
+use crate::Miim;
+
+use crate::{
+    registers::{auto_negotiation::*, leader_follower::*, *},
+    LinkSpeed, LinkState,
+};
+
+use core::ops::ControlFlow::{Break, Continue};
+
+type Control<T> = core::ops::ControlFlow<Result<LinkState, LinkStateError>, T>;
+
+/// Errors that can occur when attempting to determine
+/// the state of a link.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LinkStateError {
+    /// No link has been established yet.
+    NoLink,
+    /// Autonegotiation is enabled, but has not completed yet.
+    AutonegotiationNotCompleted,
+    /// Autonegotiation is enabled, but the PHY does not support extended
+    /// capabilities. This means that it lacks the registers required to
+    /// read out the autonegotiation status, so the status cannot be read out.
+    ExtendedCapabilities,
+    /// Autonegotiation is enabled, but he link partner does not support auto negotiation.
+    LinkPartnerNotAutonegotiationAble,
+    /// None of the technologies supported by this PHY
+    /// are supported by the autonegotitation link partner, and vice-versa.
+    NoMatchingTechnologies,
+}
+
+// Priority resolution as defined in IEEE 802.3-2022, Section 28B.3
+// 100BASE-T2 and 100BASE-T4 are ignored
+fn non_gigabit_link_state(
+    local_ta: TechnologyAbility,
+    lp_ta: TechnologyAbility,
+) -> Result<LinkState, LinkStateError> {
+    let local_100_fd = local_ta._100base_tx_fd();
+    let local_100_hd = local_ta._100base_tx_hd();
+    let local_10_fd = local_ta._10base_t_fd();
+    let local_10_hd = local_ta._10base_t_fd();
+
+    let lp_100_fd = lp_ta._100base_tx_fd();
+    let lp_100_hd = lp_ta._100base_tx_hd();
+    let lp_10_fd = lp_ta._10base_t_fd();
+    let lp_10_hd = lp_ta._10base_t_hd();
+
+    // Priority resolution as defined in IEEE 802.3-2022, Section 28B.3
+    // 100BASE-T2 and 100BASE-T4 are ignored
+    let (speed, duplex) = if local_100_fd && lp_100_fd {
+        (LinkSpeed::Mbps100, Duplex::Full)
+    } else if local_100_hd && lp_100_hd {
+        (LinkSpeed::Mbps100, Duplex::Half)
+    } else if local_10_fd && lp_10_fd {
+        (LinkSpeed::Mbps10, Duplex::Full)
+    } else if local_10_hd && lp_10_hd {
+        (LinkSpeed::Mbps10, Duplex::Half)
+    } else {
+        return Result::Err(LinkStateError::NoMatchingTechnologies);
+    };
+
+    Result::Ok(LinkState { speed, duplex })
+}
+
+/// A state machine describing the process of determining the link state of
+/// an (R)(G)MII PHY.
+///
+/// Each step in the process returns a [`ControlFlow`][`core::ops::ControlFlow`]. The `Break`
+/// variant indicates that a result has been obtained, while the [`Continue`] variant indicates
+/// that additional register reads are required. The value in the [`Continue`] variant will
+/// have a `next` function to drive the process further.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct GetLinkStateProcess;
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Autonegotiating {
+    pub status: BasicStatus,
+    pub control: BasicControl,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct AutonegotiatingGigabit {
+    pub advertisement: AutonegotiationAdvertisement,
+    pub link_partner_ability: AutonegotiationLinkPartnerAbility,
+}
+
+impl GetLinkStateProcess {
+    /// Perform the process in a single shot by providing all of the registers
+    /// necessary to perform the determination.
+    pub fn oneshot(
+        status: BasicStatus,
+        control: BasicControl,
+        autoneg_exp: AutonegotiationExpansion,
+        advertisement: AutonegotiationAdvertisement,
+        link_partner_ability: AutonegotiationLinkPartnerAbility,
+        lf_control: LeaderFollowerControl,
+        lf_status: LeaderFollowerStatus,
+    ) -> Result<LinkState, LinkStateError> {
+        let process = match GetLinkStateProcess::start(status, control) {
+            Continue(c) => c,
+            Break(res) => return res,
+        };
+
+        let process = match process.next(autoneg_exp, advertisement, link_partner_ability) {
+            Continue(c) => c,
+            Break(res) => return res,
+        };
+
+        process.next(lf_control, lf_status)
+    }
+
+    /// Start the process of determining the link state of a PHY.
+    pub fn start(status: BasicStatus, control: BasicControl) -> Control<Autonegotiating> {
+        if !status.link_status() {
+            return Break(Err(LinkStateError::NoLink));
+        }
+
+        let link_config = control.get_link_config();
+        let autoneg_completed = status.autonegotiation_complete();
+
+        let result = match (link_config, autoneg_completed) {
+            (BasicControlLinkConfig::Manual { duplex, speed }, _) => Ok(LinkState {
+                speed,
+                duplex: match duplex {
+                    DuplexConfig::Half => Duplex::Half,
+                    DuplexConfig::Full { .. } => Duplex::Full,
+                },
+            }),
+            (BasicControlLinkConfig::Autonegotiate { .. }, false) => {
+                Err(LinkStateError::AutonegotiationNotCompleted)
+            }
+            (BasicControlLinkConfig::Autonegotiate { .. }, true) => {
+                if !status.extended_capabilities() {
+                    return Break(Err(LinkStateError::ExtendedCapabilities));
+                }
+
+                return Continue(Autonegotiating { status, control });
+            }
+        };
+
+        Break(result)
+    }
+}
+
+impl Autonegotiating {
+    /// Perform the next step of determining the link state.
+    pub fn next(
+        self,
+        autoneg_exp: AutonegotiationExpansion,
+        advertisement: AutonegotiationAdvertisement,
+        link_partner_ability: AutonegotiationLinkPartnerAbility,
+    ) -> Control<AutonegotiatingGigabit> {
+        if !autoneg_exp.link_partner_autonegotiation_able() {
+            return Break(Err(LinkStateError::LinkPartnerNotAutonegotiationAble));
+        }
+
+        // Having extended status is equivalent to being 1000 Mbit capable
+        let gigabit = self.status.extended_status();
+
+        // According to 802.3-2022, Table 40-3, the LEADER-FOLLOWER status bits
+        // are only valid if 6.1 Page Received bit has been set.
+        //
+        // However, this bit latches low, which means we can only use it to
+        // read the correct link state exactly once. Instead, we will assume
+        // that the link partner being next page able is enough of an indication
+        // of gigabit-ability.
+        let partner_np_able = autoneg_exp.link_partner_next_page_able();
+
+        if gigabit && partner_np_able {
+            return Continue(AutonegotiatingGigabit {
+                advertisement,
+                link_partner_ability,
+            });
+        }
+
+        Break(non_gigabit_link_state(
+            advertisement.technology_ability(),
+            link_partner_ability.technology_ability(),
+        ))
+    }
+}
+
+impl AutonegotiatingGigabit {
+    /// Performt the next step in the autonegotiation process. In the case of this step,
+    /// a [`Result`] is guaranteed to be returned.
+    pub fn next(
+        self,
+        lf_control: LeaderFollowerControl,
+        lf_status: LeaderFollowerStatus,
+    ) -> Result<LinkState, LinkStateError> {
+        let local_1000_fd = lf_control._1000base_t_fd();
+        let local_1000_hd = lf_control._1000base_t_hd();
+
+        let lp_1000_fd = lf_status._1000base_t_fd();
+        let lp_1000_hd = lf_status._1000base_t_hd();
+
+        if local_1000_fd && lp_1000_fd {
+            Ok(LinkState {
+                speed: LinkSpeed::Mbps1000,
+                duplex: Duplex::Full,
+            })
+        } else if local_1000_hd && lp_1000_hd {
+            Ok(LinkState {
+                speed: LinkSpeed::Mbps1000,
+                duplex: Duplex::Half,
+            })
+        } else {
+            non_gigabit_link_state(
+                self.advertisement.technology_ability(),
+                self.link_partner_ability.technology_ability(),
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::assert_matches;
+    use std::ops::ControlFlow;
+
+    use crate::{
+        registers::{
+            auto_negotiation::AutonegotiationExpansion,
+            leader_follower::{LeaderFollowerControl, LeaderFollowerStatus},
+            BasicControl, BasicControlLinkConfig, BasicStatus, Duplex, DuplexConfig,
+        },
+        GetLinkStateProcess, LinkSpeed, LinkState, LinkStateError,
+    };
+
+    fn control_to_determined_pairs() -> impl Iterator<Item = (BasicControlLinkConfig, LinkState)> {
+        [LinkSpeed::Mbps10, LinkSpeed::Mbps100, LinkSpeed::Mbps1000]
+            .into_iter()
+            .flat_map(|speed| {
+                [
+                    (
+                        BasicControlLinkConfig::Manual {
+                            duplex: DuplexConfig::Half,
+                            speed,
+                        },
+                        LinkState {
+                            speed,
+                            duplex: Duplex::Half,
+                        },
+                    ),
+                    (
+                        BasicControlLinkConfig::Manual {
+                            duplex: DuplexConfig::Full {
+                                unidirectional: true,
+                            },
+                            speed,
+                        },
+                        LinkState {
+                            speed,
+                            duplex: Duplex::Full,
+                        },
+                    ),
+                    (
+                        BasicControlLinkConfig::Manual {
+                            duplex: DuplexConfig::Full {
+                                unidirectional: false,
+                            },
+                            speed,
+                        },
+                        LinkState {
+                            speed,
+                            duplex: Duplex::Full,
+                        },
+                    ),
+                ]
+            })
+    }
+
+    #[test]
+    fn no_link() {
+        let mut status = BasicStatus::from(0);
+        status.set_link_status(false);
+
+        let control = BasicControl::from(0);
+        let start = GetLinkStateProcess::start(status, control);
+
+        assert_matches!(start, ControlFlow::Break(Err(LinkStateError::NoLink)));
+    }
+
+    #[test]
+    fn link_no_autonegotiation() {
+        for (config, expected) in control_to_determined_pairs() {
+            let mut status = BasicStatus::from(0);
+            status.set_link_status(true);
+            status.set_autonegotiation_complete(false);
+
+            let mut control = BasicControl::from(0);
+            control.set_link_config(config);
+
+            let start = GetLinkStateProcess::start(status, control);
+
+            assert_matches!(start, ControlFlow::Break(Ok(s)) if s == expected, "{:?} != {:?}", start, expected);
+        }
+    }
+
+    #[test]
+    fn link_autoneg_incomplete() {
+        let mut status = BasicStatus::from(0);
+        status.set_link_status(true);
+        status.set_autonegotiation_complete(false);
+        status.set_extended_capabilities(true);
+
+        let mut control = BasicControl::from(0);
+        control.set_link_config(BasicControlLinkConfig::Autonegotiate { restart: false });
+
+        let start = GetLinkStateProcess::start(status, control);
+
+        assert_matches!(
+            start,
+            ControlFlow::Break(Err(LinkStateError::AutonegotiationNotCompleted))
+        );
+    }
+
+    #[test]
+    fn link_autonegotiation_no_ext_cap() {
+        let mut status = BasicStatus::from(0);
+        status.set_link_status(true);
+        status.set_autonegotiation_complete(true);
+
+        let mut control = BasicControl::from(0);
+        control.set_link_config(BasicControlLinkConfig::Autonegotiate { restart: false });
+
+        let start = GetLinkStateProcess::start(status, control);
+
+        assert_matches!(
+            start,
+            ControlFlow::Break(Err(LinkStateError::ExtendedCapabilities))
+        );
+    }
+
+    #[test]
+    fn link_autonegotiation_complete() {
+        let mut status = BasicStatus::from(0);
+        status.set_link_status(true);
+        status.set_autonegotiation_complete(true);
+        status.set_extended_capabilities(true);
+
+        let mut control = BasicControl::from(0);
+        control.set_link_config(BasicControlLinkConfig::Autonegotiate { restart: false });
+
+        let start = GetLinkStateProcess::start(status, control);
+
+        assert_matches!(start, ControlFlow::Continue(_));
+    }
+
+    #[test]
+    fn link_autonegotiation_partner_unable() {
+        let mut status = BasicStatus::from(0);
+        status.set_link_status(true);
+        status.set_autonegotiation_complete(true);
+        status.set_extended_capabilities(true);
+
+        let mut control = BasicControl::from(0);
+        control.set_link_config(BasicControlLinkConfig::Autonegotiate { restart: false });
+
+        let start = GetLinkStateProcess::start(status, control);
+        let autoneg = start.continue_value().unwrap();
+
+        let autoneg = autoneg.next(0u16.into(), 0u16.into(), 0u16.into());
+
+        assert_matches!(
+            autoneg,
+            ControlFlow::Break(Err(LinkStateError::LinkPartnerNotAutonegotiationAble))
+        );
+    }
+
+    #[test]
+    fn link_autonegotiation_non_gmii_to_non_gmii() {
+        // NB: all non-`true, true` combinations represent a non-gmii
+        // (advertising) PHY autonegotiating with another non-gmii (advertising) PHY.
+        for (ext_status, remote_next_page) in [(false, false), (false, true), (false, true)] {
+            let mut status = BasicStatus::from(0);
+            status.set_link_status(true);
+            status.set_autonegotiation_complete(true);
+            status.set_extended_capabilities(true);
+            status.set_extended_status(ext_status);
+
+            let mut control = BasicControl::from(0);
+            control.set_link_config(BasicControlLinkConfig::Autonegotiate { restart: false });
+
+            let start = GetLinkStateProcess::start(status, control);
+            let autoneg = start.continue_ok().unwrap();
+
+            let mut exp = AutonegotiationExpansion::from(0);
+            exp.set_link_partner_autonegotiation_able(true);
+            exp.set_link_partner_next_page_able(remote_next_page);
+
+            let autoneg = autoneg.next(exp, 0u16.into(), 0u16.into());
+
+            // NOTE: only `non_gigabit_link_state` can return this error variant.
+            assert_matches!(
+                autoneg,
+                ControlFlow::Break(Err(LinkStateError::NoMatchingTechnologies)),
+                "ext_status: {ext_status}, remote_next_page: {remote_next_page}",
+            );
+        }
+    }
+
+    #[test]
+    fn link_autonegotiation_gmii_to_gmii() {
+        #[rustfmt::skip]
+        const COMBINATIONS: [(bool, bool); 4] = [
+            (true,  true),
+            (false, true),
+            (true,  false),
+            (false, false)
+        ];
+
+        let cases = COMBINATIONS.into_iter().flat_map(|hd| {
+            COMBINATIONS.into_iter().map(move |fd| {
+                let duplex = if fd.0 && fd.1 {
+                    Some(Duplex::Full)
+                } else if hd.0 && hd.1 {
+                    Some(Duplex::Half)
+                } else {
+                    None
+                };
+
+                (hd, fd, duplex)
+            })
+        });
+
+        for tuple in cases {
+            let ((local_hd, remote_hd), (local_fd, remote_fd), expected) = tuple;
+            let mut status = BasicStatus::from(0);
+            status.set_link_status(true);
+            status.set_autonegotiation_complete(true);
+            status.set_extended_capabilities(true);
+            status.set_extended_status(true);
+
+            let mut control = BasicControl::from(0);
+            control.set_link_config(BasicControlLinkConfig::Autonegotiate { restart: false });
+
+            let start = GetLinkStateProcess::start(status, control);
+            let autoneg = start.continue_value().unwrap();
+
+            let mut exp = AutonegotiationExpansion::from(0);
+            exp.set_link_partner_autonegotiation_able(true);
+            exp.set_next_page_able(true);
+            exp.set_link_partner_next_page_able(true);
+
+            let autoneg_gbit = autoneg
+                .next(exp, 0u16.into(), 0u16.into())
+                .continue_ok()
+                .unwrap();
+
+            let mut lf_control = LeaderFollowerControl::from(0);
+            lf_control.set__1000base_t_fd(local_fd);
+            lf_control.set__1000base_t_hd(local_hd);
+
+            let mut lf_status = LeaderFollowerStatus::from(0);
+            lf_status.set__1000base_t_fd(remote_fd);
+            lf_status.set__1000base_t_hd(remote_hd);
+
+            let gbit = autoneg_gbit.next(lf_control, lf_status);
+
+            if let Some(expected) = expected {
+                assert_matches!(
+                    gbit,
+                    Ok(
+                        LinkState {
+                        speed: LinkSpeed::Mbps1000,
+                        duplex
+                    }) if duplex == expected,
+                    "{tuple:?}",
+                )
+            } else {
+                // NOTE: only `non_gigabit_link_state` can return this error variant.
+                assert_matches!(gbit, Err(LinkStateError::NoMatchingTechnologies));
+            }
+        }
+    }
+}

--- a/ieee802_3_miim/src/registers.rs
+++ b/ieee802_3_miim/src/registers.rs
@@ -40,7 +40,7 @@ mod basic;
 pub mod leader_follower;
 
 pub use basic::{
-    BasicControl, BasicControlLinkConfig, BasicStatus, Duplex, DuplexMode, ExtendedStatus,
+    BasicControl, BasicControlLinkConfig, BasicStatus, Duplex, DuplexConfig, ExtendedStatus,
 };
 
 use crate::RegisterAddress;

--- a/ieee802_3_miim/src/registers/auto_negotiation.rs
+++ b/ieee802_3_miim/src/registers/auto_negotiation.rs
@@ -77,7 +77,7 @@ pub struct AutonegotiationExpansion {
     pub link_partner_autonegotiation_able: bool,
     /// Whether a new page was received from the link partner.
     ///
-    /// This field is reset to 0 when on a read of the register.
+    /// This field is reset to 0 when the register is read.
     pub page_received: bool,
     /// Whether the local device is next-page able.
     pub next_page_able: bool,

--- a/ieee802_3_miim/src/registers/auto_negotiation.rs
+++ b/ieee802_3_miim/src/registers/auto_negotiation.rs
@@ -121,7 +121,7 @@ pub enum Selector {
 ///
 /// Defined in Annex 28B.2 and 28D.
 #[bitsize(7)]
-#[derive(FromBits, DebugBits, Clone, Copy, PartialEq)]
+#[derive(FromBits, DebugBits, Clone, Copy, PartialEq, Default)]
 #[cfg_attr(feature = "defmt", derive(bilge_defmt::FormatBits))]
 pub struct TechnologyAbility {
     /// Supports 10BASE-T, Half-Duplex.

--- a/ieee802_3_miim/src/registers/basic.rs
+++ b/ieee802_3_miim/src/registers/basic.rs
@@ -95,13 +95,13 @@ impl Register for ExtendedStatus {
 
 /// A duplex mode.
 #[bitsize(1)]
-#[derive(Clone, Copy, Debug, FromBits, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, FromBits, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Duplex {
-    /// Half duplex.
-    Half = 0,
     /// Full duplex.
     Full = 1,
+    /// Half duplex.
+    Half = 0,
 }
 
 /// Valid duplex mode configurations for [`BasicControl`].

--- a/ieee802_3_miim/src/registers/basic.rs
+++ b/ieee802_3_miim/src/registers/basic.rs
@@ -97,7 +97,7 @@ impl Register for ExtendedStatus {
 #[bitsize(1)]
 #[derive(Clone, Copy, Debug, FromBits, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum DuplexMode {
+pub enum Duplex {
     /// Half duplex.
     Half = 0,
     /// Full duplex.
@@ -107,7 +107,7 @@ pub enum DuplexMode {
 /// Valid duplex mode configurations for [`BasicControl`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum Duplex {
+pub enum DuplexConfig {
     /// Half duplex.
     Half,
     /// Full duplex.
@@ -131,7 +131,7 @@ pub enum BasicControlLinkConfig {
     /// Manual configuration of the link state.
     Manual {
         /// The duplex to use.
-        duplex: Duplex,
+        duplex: DuplexConfig,
         /// The speed to use.
         speed: LinkSpeed,
     },
@@ -156,7 +156,7 @@ pub struct BasicControl {
     speed_sel_msb: bool,
     /// Enable the collision test signal.
     pub collision_test: bool,
-    duplex_mode: DuplexMode,
+    duplex_mode: Duplex,
     restart_autonegotiation: bool,
     /// Electrically isolate the PHY from its (Gigabit) Media Independent
     /// Interface.
@@ -187,8 +187,8 @@ impl BasicControl {
             }
         } else {
             let duplex = match self.duplex_mode() {
-                DuplexMode::Half => Duplex::Half,
-                DuplexMode::Full => Duplex::Full {
+                Duplex::Half => DuplexConfig::Half,
+                Duplex::Full => DuplexConfig::Full {
                     unidirectional: self.unidirectional_enable(),
                 },
             };
@@ -214,9 +214,9 @@ impl BasicControl {
             BasicControlLinkConfig::Manual { duplex, speed } => {
                 self.set_autonegotiation_enable(false);
                 match duplex {
-                    Duplex::Half => self.set_duplex_mode(DuplexMode::Half),
-                    Duplex::Full { unidirectional } => {
-                        self.set_duplex_mode(DuplexMode::Full);
+                    DuplexConfig::Half => self.set_duplex_mode(Duplex::Half),
+                    DuplexConfig::Full { unidirectional } => {
+                        self.set_duplex_mode(Duplex::Full);
                         self.set_unidirectional_enable(unidirectional);
                     }
                 }
@@ -241,23 +241,23 @@ impl Register for BasicControl {
 #[cfg(test)]
 mod test {
     use crate::{
-        registers::{BasicControl, DuplexMode},
+        registers::{BasicControl, Duplex},
         LinkSpeed,
     };
 
-    use super::{BasicControlLinkConfig, Duplex};
+    use super::{BasicControlLinkConfig, DuplexConfig};
 
     #[test]
     fn set_manual_mode_disables_autonegotiation() {
         let mut status = BasicControl::from(0);
         status.set_link_config(BasicControlLinkConfig::Manual {
-            duplex: Duplex::Half,
+            duplex: DuplexConfig::Half,
             speed: LinkSpeed::Mbps100,
         });
 
         assert!(!status.autonegotiation_enable());
         assert!(status.speed_sel_lsb());
         assert!(!status.speed_sel_msb());
-        assert_eq!(status.duplex_mode(), DuplexMode::Half);
+        assert_eq!(status.duplex_mode(), Duplex::Half);
     }
 }


### PR DESCRIPTION
It is very desirable for the annoying logic used to determine link speed to be sans-io. The way to do that is by implementing it as a state machine, and `ControlFlow` nicely supports how that state machine can and should advance.

Rewrite the logic into a state machine and expose it.