### PR TITLE
optional dependency should not have implicit feature

### DIFF
--- a/ieee802_3_miim/Cargo.toml
+++ b/ieee802_3_miim/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 
 [features]
 default = [ "mmd" ]
-defmt = [ "dep:defmt", "bilge-defmt" ]
+defmt = [ "dep:defmt", "dep:bilge-defmt" ]
 
 mmd = [ ]
 


### PR DESCRIPTION
Using an `optional` dependency without ever specifying it as a `dep:`-activated dependency by other features creates an unwanted implicit feature. Remove it